### PR TITLE
experience_bonus_mult bug fix

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -310,7 +310,7 @@ pub struct Stats {
     /// Session experience multiplier?
     pub session_experience_mult: f64,
     /// Experience bonus multiplier?
-    pub experience_bonus_mult: u64,
+    pub experience_bonus_mult: f64,
     /// Total session experience
     pub total_session_experience: u64,
     /// Last session timestamp


### PR DESCRIPTION
Error: Json(Error("invalid type: floating point `1.15`, expected u64", line: 1, column: 191630))
Causes a JSON error because it can be a floating point but is declared as an integer
I found the causing bug by tracing down the value of 1.15 in my profiles JSON and it came to be experience_bonus_mult shown in my profile by "ExperienceBonusMult":1.15