### PR TITLE
Add support for error code 232: Wrong major version

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,6 +67,9 @@ pub enum LoginError {
     /// Rate limited after too many bad login attempts.
     #[error(display = "too many login attempts")]
     RateLimited,
+    /// Library contains the wrong major version.
+    #[error(display = "wrong major version")]
+    WrongMajorVersion,
 }
 
 pub(crate) async fn login(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,7 @@ pub(crate) fn handle_error2(error: ErrorResponse) -> Result<()> {
         214 => Err(LoginError::CaptchaRequired)?,
         228 => Err(RagfairError::InvalidBarterItems)?,
         230 => Err(LoginError::RateLimited)?,
+        232 => Err(LoginError::WrongMajorVersion)?,
         263 => Err(Error::Maintenance)?,
         1000 => Err(Error::BackendError)?,
         1501 => Err(RagfairError::MaxOfferCount)?,


### PR DESCRIPTION
```
[2020-03-04T03:03:30Z DEBUG tarkov::auth] Response: {"err":232,"errmsg":"232 - Wrong major version","data":null}
Error: UnknownAPIError(232)
```