### PR TITLE
Update quest struct with optional fields

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1603,15 +1603,15 @@ pub struct Quest {
     /// Quest name
     pub name: String,
     /// Quest description
-    pub description: String,
+    pub description: Option<String>,
     /// Quest note
     pub note: Option<String>,
     /// Quest fail message
-    pub fail_message_text: String,
+    pub fail_message_text: Option<String>,
     /// Quest start message
-    pub started_message_text: String,
+    pub started_message_text: Option<String>,
     /// Quest success message
-    pub success_message_text: String,
+    pub success_message_text: Option<String>,
     /// Quest conditions
     pub conditions: HashMap<String, String>,
     /// Quest location

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
 
-const GAME_VERSION: &str = "0.12.3.6152";
+const GAME_VERSION: &str = "0.12.4.6675";
 const LAUNCHER_VERSION: &str = "0.9.3.1057";
 const UNITY_VERSION: &str = "2018.4.13f1";
 


### PR DESCRIPTION
It seems that there are "ghost quests", which only have dependents and nothing else. This broke the localization code. This fixes that, by making them optional.